### PR TITLE
Fix RGB -> HSL conversion

### DIFF
--- a/lua/colors.lua
+++ b/lua/colors.lua
@@ -109,9 +109,9 @@ M.rgb_to_hsl = rgb_to_hsl
 
 -- already local, see at the bottom
 function rgb_string_to_hsl(rgb)
-   return rgb_to_hsl(tonumber(rgb:sub(2,3), 16)/256, 
-                     tonumber(rgb:sub(4,5), 16)/256,
-                     tonumber(rgb:sub(6,7), 16)/256)
+   return rgb_to_hsl(tonumber(rgb:sub(2,3), 16)/255, 
+                     tonumber(rgb:sub(4,5), 16)/255,
+                     tonumber(rgb:sub(6,7), 16)/255)
 end
 M.rgb_string_to_hsl = rgb_string_to_hsl
 


### PR DESCRIPTION
The previous version modified some RGB values in which R, G, or B was above 0x80 when it converted them from RGB to HSL and back:
```
colors = require 'colors'
white = colors.new '#ffffff'
assert(tostring(white) == '#fefefe')
```
Dividing R, G, and B by 255 rather than 256 seems to fix this problem.